### PR TITLE
add method not allowed

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -183,3 +183,8 @@ class TestAccountService(TestCase):
         account = self._create_accounts(1)[0]
         resp = self.client.delete(f"{BASE_URL}/{account.id}")
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_method_not_allowed(self):
+        """It should not allow an illegal method call"""
+        resp = self.client.delete(BASE_URL)
+        self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)


### PR DESCRIPTION
nosetests result

```
(venv) theia:devops-capstone-project$ nosetests

Test Flask CLI Commands
- It should call the db-create command

Test Cases for Account Model
- It should Create an account and add it to the database
- It should Create an Account and assert that it exists
- It should Delete an account from the database
- It should Deserialize an account
- It should not Deserialize an account with a KeyError
- It should not Deserialize an account with a TypeError
- It should Find an Account by name
- It should List all Accounts in the database
- It should Read an account
- It should Serialize an account
- It should Update an account

Account Service Tests
- It should not Create an Account when sending the wrong data
- It should Create a new Account
- It should Delete an Account
- It should Read a single Account
- It should Get a list of Accounts
- It should not Read an Account that is not found
- It should be healthy
- It should get 200_OK from the Home Page
- It should not allow an illegal method call
- It should not Create an Account when sending the wrong media type
- It should Update an existing Account
- It should Not Update an existing Account if does not exist

Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
service/__init__.py                   18      3    83%   32-35
service/common/__init__.py             0      0   100%
service/common/cli_commands.py         7      0   100%
service/common/error_handlers.py      32      3    91%   76-78
service/common/log_handlers.py        10      1    90%   21
service/common/status.py              46      0   100%
service/config.py                     11      0   100%
service/models.py                     69      3    96%   32, 98, 127
service/routes.py                     56      0   100%
----------------------------------------------------------------
TOTAL                                249     10    96%
----------------------------------------------------------------------
Ran 24 tests in 1.135s

OK
```